### PR TITLE
将Gravatar地址源更换为CSS.NET

### DIFF
--- a/lib/Ss/User/Comm.php
+++ b/lib/Ss/User/Comm.php
@@ -38,7 +38,7 @@ class Comm {
     //Gravatar
     static function Gravatar( $email, $s = 80, $d = 'mm', $r = 'g', $img = false, $atts = array() ) {
         //$url = 'http://gravatar.duoshuo.com/avatar/';
-        $url = 'https://secure.gravatar.com/avatar/';
+        $url = 'https://cdn.css.net/avatar';
         $url .= md5( strtolower( trim( $email ) ) );
         $url .= "?s=$s&d=$d&r=$r";
         if ( $img ) {


### PR DESCRIPTION
将Gravatar地址源更换为CSS.NET，解决头像被墙无法显示。
